### PR TITLE
Fix 1.19.1 Protocol PacketIn and PacketOut

### DIFF
--- a/src/main/java/dev/lone/bungeepackfix/libs/packetlistener/packets/RespackSendPacketOut.java
+++ b/src/main/java/dev/lone/bungeepackfix/libs/packetlistener/packets/RespackSendPacketOut.java
@@ -158,7 +158,7 @@ public class RespackSendPacketOut extends PacketOut
                           boolean checkMsg)
     {
         if (this == o)
-        return true;
+            return true;
 
         if (o == null || this.getClass() != o.getClass())
             return false;

--- a/src/main/java/dev/lone/bungeepackfix/libs/packetlistener/packets/RespackSendPacketOut.java
+++ b/src/main/java/dev/lone/bungeepackfix/libs/packetlistener/packets/RespackSendPacketOut.java
@@ -50,7 +50,7 @@ public class RespackSendPacketOut extends PacketOut
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_16_2, 0x38);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_17, 0x3C);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19, 0x3A);
-            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19_1, 0x23);
+            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19_1, 0x3D);
         }catch (Exception ignored)
         {
             // Failed to find constant, probably Bungeecord is outdated.

--- a/src/main/java/dev/lone/bungeepackfix/libs/packetlistener/packets/RespackStatusPacketIn.java
+++ b/src/main/java/dev/lone/bungeepackfix/libs/packetlistener/packets/RespackStatusPacketIn.java
@@ -44,7 +44,7 @@ public class RespackStatusPacketIn extends PacketIn
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_14, 0x1F);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_16, 0x21);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19, 0x23);
-            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19_1, 0x3A);
+            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19_1, 0x24);
         }catch (Exception ignored)
         {
             // Failed to find constant, probably Bungeecord is outdated.


### PR DESCRIPTION
Due to the wrong packet type mapping, the plugin stopped working.
I have fixed this.