### PR TITLE
Fix compatible with 1.20.2

### DIFF
--- a/src/main/java/dev/lone/bungeepackfix/bungee/packets/impl/ClientboundResourcePackPacket.java
+++ b/src/main/java/dev/lone/bungeepackfix/bungee/packets/impl/ClientboundResourcePackPacket.java
@@ -44,7 +44,7 @@ public class ClientboundResourcePackPacket extends ClientboundPacket
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19_1, 0x3D);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19_3, 0x3C);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19_4, 0x40);
-            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_20_2, 0x06);
+            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_20_2, 0x42);
         }
         catch (Exception ignored)
         {

--- a/src/main/java/dev/lone/bungeepackfix/bungee/packets/impl/ServerboundResourcePackPacket.java
+++ b/src/main/java/dev/lone/bungeepackfix/bungee/packets/impl/ServerboundResourcePackPacket.java
@@ -36,6 +36,7 @@ public class ServerboundResourcePackPacket extends ServerboundPacket
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_16, 0x21);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19, 0x23);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19_1, 0x24);
+            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_20_2, 0x27);
         }
         catch (Exception ignored)
         {


### PR DESCRIPTION
Hello,

As always, I create this pull request to help you to update the packet for new Minecraft version, 1.20.2.

This should fix problems with 1.20.2 client still do resource pack reload on server switch.