### PR TITLE
Fixed hash equality check not working on Velocity

### DIFF
--- a/src/main/java/dev/lone/bungeepackfix/velocity/PlayersPackCache.java
+++ b/src/main/java/dev/lone/bungeepackfix/velocity/PlayersPackCache.java
@@ -5,6 +5,7 @@ import com.velocitypowered.api.proxy.player.ResourcePackInfo;
 import dev.lone.bungeepackfix.generic.AbstractPlayersPackCache;
 import dev.lone.bungeepackfix.generic.PackUtility;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.UUID;
@@ -54,7 +55,7 @@ public class PlayersPackCache extends AbstractPlayersPackCache
         final String prevUrl = PackUtility.removeHashtag(ignoreHashtagInUrl, playerPack.getUrl());
 
         return (Objects.equals(prevUrl, newUrl)) &&
-                (!checkHash || Objects.equals(playerPack.getHash(), newPack.getHash())) &&
+                (!checkHash || Arrays.equals(playerPack.getHash(), newPack.getHash())) &&
                 (!checkForced || Objects.equals(playerPack.getShouldForce(), newPack.getShouldForce())) &&
                 (!checkMsg || Objects.equals(playerPack.getPrompt(), newPack.getPrompt()))
                 ;


### PR DESCRIPTION
As is, `equal_pack_attributes.hash` does not function correctly on Velocity, because Objects.equals is used on a byte array, which only checks for reference equality, which cannot work because the getter [always creates a clone](https://github.com/PaperMC/Velocity/blob/59567512845ce5e7aed631a489c32435fb56c19d/proxy/src/main/java/com/velocitypowered/proxy/connection/player/VelocityResourcePackInfo.java#L72).
After a quick test, the resource pack seems to be correctly skipped.