### PR TITLE
Fix of players getting kicked while editing Anvil Text

### DIFF
--- a/src/main/java/dev/lone/bungeepackfix/bungee/packets/impl/ServerboundResourcePackPacket.java
+++ b/src/main/java/dev/lone/bungeepackfix/bungee/packets/impl/ServerboundResourcePackPacket.java
@@ -40,7 +40,9 @@ public class ServerboundResourcePackPacket extends ServerboundPacket
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_14, 0x1F);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_16, 0x21);
             PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_19, 0x23);
-            PACKET_MAP.put(Packet.versionIdByName("MINECRAFT_1_20_3"), 0x28);
+            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_20, 0x24);
+            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_20_2, 0x27);
+            PACKET_MAP.put(ProtocolConstants.MINECRAFT_1_20_3, 0x28);
         }
         catch (Exception ignored)
         {


### PR DESCRIPTION
I've found a fix for an issue that is only happening to players that are using version 1.20, 1.20.1 and 1.20.2

With this PR merged, this issue will be resolved. 

Closes https://github.com/LoneDev6/BungeePackFix/issues/54