### PR TITLE
catch exception when read ClientboundResourcePackPopPacket

### DIFF
--- a/src/main/java/dev/lone/bungeepackfix/bungee/packets/impl/ClientboundResourcePackPopPacket.java
+++ b/src/main/java/dev/lone/bungeepackfix/bungee/packets/impl/ClientboundResourcePackPopPacket.java
@@ -95,7 +95,15 @@ public class ClientboundResourcePackPopPacket extends ClientboundPacket
     @Override
     public void read(final ByteBuf buf)
     {
-        id = buf.readBoolean() ? Optional.of(readUUID(buf)) : Optional.empty();
+        if (buf.readBoolean()) {
+            try {
+                id = Optional.of(readUUID(buf));
+            } catch (Throwable ignored) {
+                id = Optional.empty();
+            }
+        } else {
+            id = Optional.empty();
+        }
     }
 
     @Override


### PR DESCRIPTION
The solution may not absolutely correct but it works well on my server.  
There is no any data after the uuid. So I think catch it mindlessly will be ok.

Without `try-catch` the `readUUID`, player kicked out. (1.20.4 server, 1.21.1 client, with ViaVersion)

```
[01:02:57] [Netty Worker IO Thread #13/WARN]: [/0.0.0.0:5589|LittleCatX] <-> DownstreamBridge <-> [test] - could not decode packet!
io.netty.handler.codec.DecoderException: java.lang.IndexOutOfBoundsException: readerIndex(3) + length(8) exceeds writerIndex(5): PooledSlicedByteBuf(ridx: 3, widx: 5, cap: 5/5, unwrapped: PooledUnsafeDirectByteBuf(ridx: 852, widx: 2048, cap: 2048))
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:98) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:455) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: java.lang.IndexOutOfBoundsException: readerIndex(3) + length(8) exceeds writerIndex(5): PooledSlicedByteBuf(ridx: 3, widx: 5, cap: 5/5, unwrapped: PooledUnsafeDirectByteBuf(ridx: 852, widx: 2048, cap: 2048))
	at io.netty.buffer.AbstractByteBuf.checkReadableBytes0(AbstractByteBuf.java:1442) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.buffer.AbstractByteBuf.readLong(AbstractByteBuf.java:835) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at net.md_5.bungee.protocol.DefinedPacket.readUUID(DefinedPacket.java:330) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at dev.lone.bungeepackfix.bungee.packets.impl.ClientboundResourcePackPopPacket.read(ClientboundResourcePackPopPacket.java:98) ~[?:?]
	at dev.lone.bungeepackfix.bungee.packets.impl.ClientboundResourcePackPopPacket.read(ClientboundResourcePackPopPacket.java:104) ~[?:?]
	at net.md_5.bungee.protocol.DefinedPacket.read(DefinedPacket.java:534) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at net.md_5.bungee.protocol.MinecraftDecoder.decode(MinecraftDecoder.java:62) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at net.md_5.bungee.protocol.MinecraftDecoder.decode(MinecraftDecoder.java:13) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:88) ~[waterfall-1.21-579.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579]
	... 26 more
```